### PR TITLE
[#17] refactor: 독서 기록 동시성 문제 관련 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework:spring-aspects'
 	testFixturesImplementation ('com.github.javafaker:javafaker:1.0.2') { exclude module: 'snakeyaml' }
 	testFixturesImplementation group: 'org.yaml', name: 'snakeyaml', version: '2.2'
 }

--- a/src/main/java/com/flab/readnshare/domain/book/domain/Book.java
+++ b/src/main/java/com/flab/readnshare/domain/book/domain/Book.java
@@ -24,7 +24,7 @@ public class Book extends BaseTimeEntity {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String isbn;
 
     private String image;

--- a/src/main/java/com/flab/readnshare/domain/review/domain/Review.java
+++ b/src/main/java/com/flab/readnshare/domain/review/domain/Review.java
@@ -32,6 +32,9 @@ public class Review extends BaseTimeEntity {
     @JoinColumn(name = "book_id", foreignKey = @ForeignKey(name = "fk_review_to_book"))
     private Book book;
 
+    @Version
+    private Long version;
+
     @Builder
     public Review(Long id, String content, Member member, Book book) {
         this.id = id;

--- a/src/main/java/com/flab/readnshare/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/flab/readnshare/domain/review/repository/ReviewRepository.java
@@ -1,7 +1,15 @@
 package com.flab.readnshare.domain.review.repository;
 
 import com.flab.readnshare.domain.review.domain.Review;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("SELECT r FROM Review r WHERE r.id = :id")
+    Optional<Review> findByIdForUpdate(Long id);
 }

--- a/src/main/java/com/flab/readnshare/domain/review/service/ReviewService.java
+++ b/src/main/java/com/flab/readnshare/domain/review/service/ReviewService.java
@@ -8,8 +8,16 @@ import com.flab.readnshare.domain.review.domain.Review;
 import com.flab.readnshare.domain.review.dto.SaveReviewRequestDto;
 import com.flab.readnshare.domain.review.dto.UpdateReviewRequestDto;
 import com.flab.readnshare.domain.review.repository.ReviewRepository;
+import com.flab.readnshare.global.common.exception.MemberException;
 import com.flab.readnshare.global.common.exception.ReviewException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +25,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 @RequiredArgsConstructor
+@EnableRetry
+@Slf4j
 public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final BookService bookService;
@@ -36,13 +46,24 @@ public class ReviewService {
         return reviewRepository.save(review).getId();
     }
 
+    @Retryable(
+            retryFor = {ObjectOptimisticLockingFailureException.class}
+            , maxAttempts = 3
+            , backoff = @Backoff(delay = 1000)
+    )
     public Long update(Long reviewId, Member signInMember, UpdateReviewRequestDto dto) {
-        Review review = findById(reviewId);
+        Review review = reviewRepository.findByIdForUpdate(reviewId).orElseThrow();
         review.verifyMember(signInMember);
 
         review.update(dto.getContent());
 
         return review.getId();
+    }
+
+    @Recover
+    public Long recover(ObjectOptimisticLockingFailureException ex, Long reviewId, Member signInMember, UpdateReviewRequestDto dto) {
+        log.error("review update failed... error: {}", ex.getMessage());
+        throw ex;
     }
 
     public void delete(Long reviewId, Member signInMember) {

--- a/src/main/java/com/flab/readnshare/global/common/advice/ApiExceptionAdvice.java
+++ b/src/main/java/com/flab/readnshare/global/common/advice/ApiExceptionAdvice.java
@@ -2,8 +2,10 @@ package com.flab.readnshare.global.common.advice;
 
 import com.flab.readnshare.global.common.exception.*;
 import com.flab.readnshare.global.common.exception.RestTemplateResponseErrorHandler.RestCallException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -15,6 +17,12 @@ public class ApiExceptionAdvice {
     protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
         ErrorResponse response = new ErrorResponse(ex, ErrorCode.INVALID_INPUT_PARAMETER);
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler({DataIntegrityViolationException.class, ObjectOptimisticLockingFailureException.class})
+    public ResponseEntity<Object> handleServerError(Exception ex) {
+        ErrorResponse response = new ErrorResponse(ErrorCode.SERVER_ERROR);
+        return new ResponseEntity<>(response, ErrorCode.SERVER_ERROR.getStatus());
     }
 
     @ExceptionHandler(MemberException.class)

--- a/src/main/java/com/flab/readnshare/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/flab/readnshare/global/common/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // Common
     INVALID_INPUT_PARAMETER(HttpStatus.BAD_REQUEST, "입력값을 확인하세요."),
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "시스템에 문제가 발생했습니다."),
 
     // Member
     EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 존재하는 회원입니다."),


### PR DESCRIPTION
- 관련된 Issue: #17

----
- **책 등록을 빠르게 2번 save 하는 경우 발생할 수 있는 문제**
1. 중복 저장: 동일한 책에 대해 n번 저장을 시도할 수 있습니다. 이로 인해 데이터가 중복되어 DB에 저장될 수 있습니다.
2. 고유 식별자(ISBN) 충돌: 연속적으로 저장되는 경우, 동일한 ISBN을 가지게 되어 데이터 정합성 문제가 발생할 수 있습니다.

- **해결방안**
유니크 제약조건을 추가했습니다.
   - 데이터베이스의 유니크 제약조건을 활용하여 중복된 데이터의 삽입을 방지할 수 있습니다.
   - 유니크 제약조건을 위반하는 경우 에러가 발생하므로 이에 대한 처리가 필요합니다.
----
- **리뷰 수정을 빠르게 2번 update 하는 경우 발생할 수 있는 문제**
1. 데이터 손실: 동시에 두 번의 저장이 발생할 경우, 두 번째 저장은 첫 번째 저장을 덮어쓸 수 있습니다.

- **해결방안**
낙관적 락을 적용했습니다.
   - 트랜잭션 충돌이 발생할 가능성이 낮다고 가정하고, 충돌이 발생했을 때만 대응합니다.
   - 주로 데이터의 충돌 가능성이 낮은 환경이나, 시스템 성능을 최대한 유지해야 하는 경우에 사용됩니다.
   - 충돌이 발생했을 때 데이터를 다시 처리해야 하기 때문에 충돌 발생 시 대응 방안을 사전에 준비해야 합니다.