### PR TITLE
[#27] chore: application-prod.yml에 있는 값들을 읽어올 수 있도록 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM openjdk:17-oracle
 EXPOSE 8080
 ARG JAR_FILE=build/libs/*-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "/app.jar"]


### PR DESCRIPTION
- 관련된 Issue: #27 
----
nginx 로드밸런싱 적용된 서버들 로그를 보니 
naver.book.id (application.yml에서 읽어오는 값)를 못 읽어온다고 에러가 나고 있었습니다 ...
application-prod.yml 생성하는 건 만들어 놓고 적용을 안시켜줬네요..ㅠ.ㅠ

