### PR TITLE
[#32] refactor: (알림 기능)특정 기술 변화에 넓은 범위의 코드 변경이 일어나지 않도록 개선

### DIFF
--- a/src/main/java/com/flab/readnshare/domain/notification/domain/FollowNotificationContent.java
+++ b/src/main/java/com/flab/readnshare/domain/notification/domain/FollowNotificationContent.java
@@ -1,0 +1,33 @@
+package com.flab.readnshare.domain.notification.domain;
+
+import com.flab.readnshare.domain.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class FollowNotificationContent implements NotificationContent {
+    private Member fromMember;
+    private Member toMember;
+
+    @Builder
+    public FollowNotificationContent(Member fromMember, Member toMember) {
+        this.fromMember = fromMember;
+        this.toMember = toMember;
+    }
+
+    @Override
+    public String getTitle() {
+        return "팔로우 시작";
+    }
+
+    @Override
+    public String getBody() {
+        return fromMember.getNickName() + "님이 팔로우하기 시작했습니다.";
+    }
+
+    @Override
+    public Long getReceiverId() {
+        return toMember.getId();
+    }
+
+}

--- a/src/main/java/com/flab/readnshare/domain/notification/domain/NotificationContent.java
+++ b/src/main/java/com/flab/readnshare/domain/notification/domain/NotificationContent.java
@@ -1,0 +1,9 @@
+package com.flab.readnshare.domain.notification.domain;
+
+public interface NotificationContent {
+    String getTitle();
+
+    String getBody();
+
+    Long getReceiverId();
+}

--- a/src/main/java/com/flab/readnshare/domain/notification/event/FollowEventListener.java
+++ b/src/main/java/com/flab/readnshare/domain/notification/event/FollowEventListener.java
@@ -2,8 +2,8 @@ package com.flab.readnshare.domain.notification.event;
 
 import com.flab.readnshare.domain.follow.event.FollowEvent;
 import com.flab.readnshare.domain.member.domain.Member;
-import com.flab.readnshare.domain.notification.service.FCMNotificationSender;
 import com.flab.readnshare.domain.notification.domain.FollowNotificationContent;
+import com.flab.readnshare.domain.notification.service.NotificationSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -11,7 +11,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 @RequiredArgsConstructor
 public class FollowEventListener {
-    private final FCMNotificationSender<FollowNotificationContent> notificationSender;
+    private final NotificationSender<FollowNotificationContent> notificationSender;
 
     @TransactionalEventListener
     public void handle(FollowEvent event) {

--- a/src/main/java/com/flab/readnshare/domain/notification/event/FollowEventListener.java
+++ b/src/main/java/com/flab/readnshare/domain/notification/event/FollowEventListener.java
@@ -2,7 +2,8 @@ package com.flab.readnshare.domain.notification.event;
 
 import com.flab.readnshare.domain.follow.event.FollowEvent;
 import com.flab.readnshare.domain.member.domain.Member;
-import com.flab.readnshare.domain.notification.service.FCMService;
+import com.flab.readnshare.domain.notification.service.FCMNotificationSender;
+import com.flab.readnshare.domain.notification.domain.FollowNotificationContent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -10,13 +11,19 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 @RequiredArgsConstructor
 public class FollowEventListener {
-    private final FCMService fcmService;
+    private final FCMNotificationSender<FollowNotificationContent> notificationSender;
 
     @TransactionalEventListener
     public void handle(FollowEvent event) {
         Member fromMember = event.getFromMember();
         Member toMember = event.getToMember();
 
-        fcmService.sendNotification(toMember.getId(), fromMember.getNickName());
+        FollowNotificationContent content = FollowNotificationContent
+                .builder()
+                .fromMember(fromMember)
+                .toMember(toMember)
+                .build();
+
+        notificationSender.sendNotification(content);
     }
 }

--- a/src/main/java/com/flab/readnshare/domain/notification/service/FCMNotificationSender.java
+++ b/src/main/java/com/flab/readnshare/domain/notification/service/FCMNotificationSender.java
@@ -1,0 +1,30 @@
+package com.flab.readnshare.domain.notification.service;
+
+import com.flab.readnshare.domain.notification.domain.NotificationContent;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FCMNotificationSender<T extends NotificationContent> implements NotificationSender<T> {
+    private final FCMService fcmService;
+
+    @Override
+    public void sendNotification(T content) {
+        String token = fcmService.getFCMToken(content.getReceiverId());
+
+        Message message = Message.builder()
+                .setNotification(Notification.builder()
+                        .setTitle(content.getTitle())
+                        .setBody(content.getBody())
+                        .build())
+                .setToken(token)
+                .build();
+
+        FirebaseMessaging.getInstance().sendAsync(message);
+    }
+
+}

--- a/src/main/java/com/flab/readnshare/domain/notification/service/FCMService.java
+++ b/src/main/java/com/flab/readnshare/domain/notification/service/FCMService.java
@@ -4,9 +4,6 @@ import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.notification.domain.FCMToken;
 import com.flab.readnshare.domain.notification.repository.FCMTokenRepository;
 import com.flab.readnshare.global.common.exception.MemberException;
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,19 +21,9 @@ public class FCMService {
         fcmTokenRepository.save(fcmToken);
     }
 
-    public void sendNotification(Long receiverId, String followerNickName) {
-        FCMToken token = fcmTokenRepository.findById(receiverId)
-                .orElseThrow(MemberException.MemberNotFoundException::new);
-
-        Message message = Message.builder()
-                .setNotification(Notification.builder()
-                        .setTitle("팔로잉")
-                        .setBody(followerNickName + "님이 팔로우하기 시작했습니다.")
-                        .build())
-                .setToken(token.getFcmTokenValue())
-                .build();
-
-        FirebaseMessaging.getInstance().sendAsync(message);
+    public String getFCMToken(Long memberId) {
+        return fcmTokenRepository.findById(memberId)
+                .orElseThrow(MemberException.MemberNotFoundException::new)
+                .getFcmTokenValue();
     }
-
 }

--- a/src/main/java/com/flab/readnshare/domain/notification/service/NotificationSender.java
+++ b/src/main/java/com/flab/readnshare/domain/notification/service/NotificationSender.java
@@ -1,0 +1,7 @@
+package com.flab.readnshare.domain.notification.service;
+
+import com.flab.readnshare.domain.notification.domain.NotificationContent;
+
+public interface NotificationSender<T extends NotificationContent> {
+    void sendNotification(T content);
+}


### PR DESCRIPTION
- 관련된 Issue: #32 
----
1. 푸시는 보내는 기술중 하나인 FCM은 과거엔 GCM 이었고, FCM도 특정 상황에선 사용하기 어려울 수 있습니다. 결국 특정 기술은 언제든 바뀔 수 있습니다. 
    만약 FCM 기술이 다른 것으로 바뀐다는 현재의 ReadNShare 는 꽤나 많은 코드가 수정되어야 할 것 같은데요. 
    이를 방지하기 위해선 어떻게 하는게 좋을까요? (특정 기술 변화에 넓은 범위의 코드 변경이 일어나지 않도록)

2. 무엇을 보낸다와 어떻게 보낸다를 구별하려면 어떻게 하는게 좋을까 (힌트: SOLID)

=> NotificationContent, NotificationSender로 분리하여 각각 FollowNotificationContent, FCMNotificationSender로 구현해보았습니다(_ _)!!