### PR TITLE
chore: AWS 배포로 전환, Docker Compose 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,11 +5,11 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v3
 
       - name: Set up JDK 17
@@ -18,47 +18,39 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Make application-prod.yml
+      - name: Create application-prod.yml
         run: |
-          cd ./src/main/resources
-          touch ./application-prod.yml
-          echo "${{ secrets.APPLICATION_YML_PROD }}" > ./application-prod.yml
+          echo "${{ secrets.APPLICATION_YML_PROD }}" > src/main/resources/application-prod.yml
         shell: bash
 
-      - name: Make firebase Directory
+      - name: Create Firebase Directory & JSON
         run: |
-          cd ./src/main/resources
-          mkdir firebase
+          mkdir -p src/main/resources/firebase
+          echo '${{ secrets.FIREBASE_ADMIN_JSON }}' > src/main/resources/firebase/readnshare-firebase-adminsdk.json
         shell: bash
 
-      - name: Make Firebase JSON
-        uses: jsdaniell/create-json@v1.2.2
-        with:
-          name: "readnshare-firebase-adminsdk.json"
-          json: ${{ secrets.FIREBASE_ADMIN_JSON }}
-          dir: 'src/main/resources/firebase/'
-
-      - name: Grant Execute Permission For Gradlew
+      - name: Grant Execute Permission for Gradlew
         run: chmod +x gradlew
 
-      - name: Build With Gradle
+      - name: Build with Gradle
         run: ./gradlew build -x test
 
-      - name: Docker build & Push
+      - name: Docker Build & Push
         run: |
-          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-          docker build -f Dockerfile -t ${{ secrets.DOCKER_USERNAME }}/readnshare .
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/readnshare .
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
           docker push ${{ secrets.DOCKER_USERNAME }}/readnshare
 
-      - name: Deploy Images with Docker compose
+      - name: Deploy with Docker Compose via SSH
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USERNAME }}
-          password: ${{ secrets.SERVER_PASSWORD }}
+          host: ${{ secrets.SERVER_HOST }}
+          key: ${{ secrets.SERVER_PRIVATE_KEY }}
+          port: ${{ secrets.SERVER_PORT }}
           script_stop: true
           script: |
-            sudo docker stop $(docker ps -a -q)
-            sudo docker rm $(docker ps -a -q)
-            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/readnshare
-            sudo docker run -d -p 8080:8080 ${{ secrets.DOCKER_USERNAME }}/readnshare
+            cd /home/compose
+            docker-compose pull
+            docker-compose up -d --no-deps
+            docker image prune -af

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+
+services:
+  app:
+    container_name: readnshare-app
+    build: .
+    ports:
+      - "8080:8080"
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:latest
+    container_name: readnshare-redis
+    hostname: redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+
+volumes:
+  redis-data:


### PR DESCRIPTION
- 관련된 Issue: #42 
---

1. 배포 환경을 기존 환경에서 AWS EC2 인스턴스로 변경했습니다.
2. 애플리케이션과 Redis를 컨테이너화하고, Docker Compose를 사용하여 컨테이너들을 관리하도록 구성했습니다.
3. GitHub Actions CD 워크플로우를 수정하여 SSH를 통해 EC2 인스턴스에 접속하여 Docker Compose 명령어를 실행하도록 변경했습니다.